### PR TITLE
Edit patient and history models and migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       
       - run:
           name: Run tests
-          command: ./vendor/bin/phpunit
+          command: ./vendor/bin/phpunit --debug --testdox
 
       - run:
           name: Report code coverage

--- a/app/Models/History.php
+++ b/app/Models/History.php
@@ -16,7 +16,11 @@ class History extends Model
       'diagnosis',
       'prescription',
       'surgical_history',
-      'social_history'
+      'social_history',
+      'other_history',
+      'investigations',
+      'treatment_therapy',
+      'summary'
     ];
 
     /**

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -24,7 +24,8 @@ class Patient extends Model
       'nationality',
       'marital_status',
       'religion',
-      'ethnicity'
+      'ethnicity',
+      'informant'
     ];
 
     public function history()

--- a/database/migrations/2019_07_20_182931_create_patients_table.php
+++ b/database/migrations/2019_07_20_182931_create_patients_table.php
@@ -30,6 +30,7 @@ class CreatePatientsTable extends Migration
             $table->string('marital_status');
             $table->string('religion');
             $table->string('ethnicity')->nullable();
+            $table->string('informant')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2019_11_12_132924_create_history_table.php
+++ b/database/migrations/2019_11_12_132924_create_history_table.php
@@ -24,6 +24,10 @@ class CreateHistoryTable extends Migration
             $table->string('prescription');
             $table->string('surgical_history');
             $table->string('social_history');
+            $table->string('other_history');
+            $table->string('investigations');
+            $table->string('treatment_therapy');
+            $table->string('summary');
             $table->timestamps();
         });
     }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -45,6 +45,7 @@ type Patient {
   marital_status: String!
   religion: String!
   ethnicity: String!
+  informant: String!
   history: [History!]! @hasMany
 }
 
@@ -59,6 +60,10 @@ type History {
   prescription: String!
   surgical_history: String!
   social_history: String!
+  other_history: String!
+  investigations: String!
+  treatment_therapy: String!
+  summary: String!
   patient: Patient @belongsTo
   doctor: Doctor @hasOne
 }
@@ -188,9 +193,10 @@ type Mutation {
   **nationality:** Nationality
   **marital_status:** Marital status. `single`, `married`, `divorced` or `widowed`
   **religion:** Religion
+  **informant** Informant
   **ethnicity:** Ethnicity
 
-  **Headers**  
+  **Headers**
   - Authorization: Root token
   """
   addPatient(
@@ -208,6 +214,7 @@ type Mutation {
     marital_status: String!
       @rules(apply: ["required", "in:single, married, divorced, widowed"])
     religion: String! @rules(apply: ["required", "alpha"])
+    informant: String @rules(apply: ["nullable", "sometimes", "string"])
     ethnicity: String! @rules(apply: ["required", "alpha"])
   ): Patient
     @middleware(checks: ["authUser:Admin", "targetUser:Patient"])
@@ -223,7 +230,7 @@ type Mutation {
   **surgical_history:** Surgical history
   **social_history:** Social history
 
-  **Headers**  
+  **Headers**
   - Authorization: Root token
   """
   addHistory(
@@ -235,7 +242,11 @@ type Mutation {
     diagnosis: String! @rules(apply: ["required", "string"])
     prescription: String! @rules(apply: ["required", "string"])
     surgical_history: String! @rules(apply: ["required", "string"])
-    social_history: String @rules(apply: ["required", "string"])
+    social_history: String! @rules(apply: ["required", "string"])
+    other_history: String! @rules(apply: ["required", "string"])
+    investigations: String! @rules(apply: ["required", "string"])
+    treatment_therapy: String! @rules(apply: ["required", "string"])
+    summary: String! @rules(apply: ["required", "string"])
   ): History
     @middleware(checks: ["authUser:Doctor"])
     @field(resolver: "HistoryMutator@addHistory")

--- a/tests/Feature/AddDoctorPatientTest.php
+++ b/tests/Feature/AddDoctorPatientTest.php
@@ -240,7 +240,7 @@ class AddDoctorPatientTest extends TestCase
             nationality: "2343",
             marital_status: "invalid",
             religion: "23432",
-            ethnicity: "83r92"
+            ethnicity: "83r92",
           ) {
             id,
             email,
@@ -292,7 +292,8 @@ class AddDoctorPatientTest extends TestCase
             nationality: "Nigerian",
             marital_status: "single",
             religion: "Christianity",
-            ethnicity: "Yoruba"
+            ethnicity: "Yoruba",
+            informant: "Informant name"
           ) {
             id,
             email,
@@ -306,7 +307,8 @@ class AddDoctorPatientTest extends TestCase
             nationality,
             marital_status,
             religion,
-            ethnicity
+            ethnicity,
+            informant
           }
       }');
 
@@ -324,6 +326,7 @@ class AddDoctorPatientTest extends TestCase
         $this->assertEquals("single", $response->json("data.addPatient.marital_status"));
         $this->assertEquals("Christianity", $response->json("data.addPatient.religion"));
         $this->assertEquals("Yoruba", $response->json("data.addPatient.ethnicity"));
+        $this->assertEquals("Informant name", $response->json("data.addPatient.informant"));
 
         // test for duplicate email and phone
         $response = $this->graphql('mutation {

--- a/tests/Feature/AddHistoryTest.php
+++ b/tests/Feature/AddHistoryTest.php
@@ -54,6 +54,10 @@ class AddHistoryTest extends TestCase
             prescription: "Prescription"
             surgical_history: "History"
             social_history: "Social"
+            other_history: "Other history",
+            investigations: "Investigations",
+            treatment_therapy: "Treatment therapy",
+            summary: "Summary"
           ) {
             id,
             patient_id,
@@ -85,6 +89,10 @@ class AddHistoryTest extends TestCase
           prescription: ""
           surgical_history: ""
           social_history: ""
+          other_history: "",
+          investigations: "",
+          treatment_therapy: "",
+          summary: ""
         ) {
           id,
           patient_id,
@@ -95,6 +103,10 @@ class AddHistoryTest extends TestCase
           surgical_history
           social_history
           diagnosis
+          other_history
+          investigations
+          treatment_therapy
+          summary
           patient {
             firstname
             lastname
@@ -115,6 +127,10 @@ class AddHistoryTest extends TestCase
         $this->assertEquals('The prescription field is required.', $response->json('errors.0.extensions.validation.prescription.0'));
         $this->assertEquals('The surgical history field is required.', $response->json('errors.0.extensions.validation.surgical_history.0'));
         $this->assertEquals('The social history field is required.', $response->json('errors.0.extensions.validation.social_history.0'));
+        $this->assertEquals('The other history field is required.', $response->json('errors.0.extensions.validation.other_history.0'));
+        $this->assertEquals('The investigations field is required.', $response->json('errors.0.extensions.validation.investigations.0'));
+        $this->assertEquals('The treatment therapy field is required.', $response->json('errors.0.extensions.validation.treatment_therapy.0'));
+        $this->assertEquals('The summary field is required.', $response->json('errors.0.extensions.validation.summary.0'));
     }
 
     public function testAddHistoryValidData()
@@ -134,6 +150,10 @@ class AddHistoryTest extends TestCase
           prescription: "Test prescription"
           surgical_history: "Test surgical history"
           social_history: "Test social history"
+          other_history: "Other history",
+          investigations: "Investigations",
+          treatment_therapy: "Treatment therapy",
+          summary: "Summary"
         ) {
           id,
           patient_id,
@@ -172,6 +192,10 @@ class AddHistoryTest extends TestCase
           prescription: "Test prescription"
           surgical_history: "Test surgical history"
           social_history: "Test social history"
+          other_history: "Other history",
+          investigations: "Investigations",
+          treatment_therapy: "Treatment therapy",
+          summary: "Summary"
         ) {
           id,
           patient_id,


### PR DESCRIPTION
This PR adds the `social_history`, `other_history`, `investigations`, `treatment_therapy` and `summary` fields to the history model and migration. It also adds the `informant` field to the patients model and migration.